### PR TITLE
在示例代码中给出subfloat的caption定义方法

### DIFF
--- a/src/chap/chap.03.elements.tex
+++ b/src/chap/chap.03.elements.tex
@@ -1108,14 +1108,14 @@ A \rule[-.4pt]{3em}{.4pt} line.
 \begin{verbatim}
 \begin{figure}[htbp]
   \centering
-  \subfloat[...]{\label{sub-fig-1}% 为子图加交叉引用
+  \subfloat[并排子图1]{\label{sub-fig-1}% 为子图加交叉引用
    \begin{minipage}{...}
     \centering
     \includegraphics[width=...]{...}
    \end{minipage}
   }
   \qquad
-  \subfloat[...]{%
+  \subfloat[并排子图2]{%
   \begin{minipage}{...}
     \centering
     \includegraphics[width=...]{...}


### PR DESCRIPTION
通过这一改动，可以明确指出subfloat中如何定义caption，因为初学者倾向于使用\captioin命令，这样就会有空白括号出现在已经定义的标题下方。