### PR TITLE
明确 `\DeclareMathOperator` 命令需要在导言区使用

### DIFF
--- a/src/chap/chap.04.math.tex
+++ b/src/chap/chap.04.math.tex
@@ -274,7 +274,7 @@ $a\bmod b \\
 \end{example}
 
 \cmdindex[amsmath]{DeclareMathOperator}
-如果表 \ref{tbl:math-functions} 中的算符不够用的话，\pkg{amsmath} 允许用户用 \amscmd{Declare\-Math\-Operator}
+如果表 \ref{tbl:math-functions} 中的算符不够用的话，\pkg{amsmath} 允许用户在导言区用 \amscmd{Declare\-Math\-Operator}
 定义自己的算符，其中带星号的命令定义带上下限的算符：
 \begin{verbatim}
 \DeclareMathOperator{\argh}{argh}


### PR DESCRIPTION
在群91940767中有人在阅读 lshort-zh-cn 时将 `\DeclareMathOperator` 命令在正文使用得到了 error, 故明确一下该命令只能在导言区使用