### PR TITLE
修改 TeXLive 安装的方式

### DIFF
--- a/src/chap/app.A.install.tex
+++ b/src/chap/app.A.install.tex
@@ -37,7 +37,7 @@
 \begin{itemize}
   \item 用于 Windows 的批处理文件：
   \begin{itemize}
-    \item \texttt{install-tl-windows.bat} 双击启动图形界面安装程序，可以在图形安装界面的 Advance 选项中定制安装；
+    \item \texttt{install-tl-windows.bat} 双击启动图形界面安装程序，可以在图形安装界面的 Advanced 选项中定制安装；
     \item 在命令提示符中输入 \texttt{install-tl-windows.bat -no-gui} 启动文本界面安装程序。
   \end{itemize}
   \item 用于 Linux 的 Perl 脚本 \texttt{install-tl} ：

--- a/src/chap/app.A.install.tex
+++ b/src/chap/app.A.install.tex
@@ -37,8 +37,7 @@
 \begin{itemize}
   \item 用于 Windows 的批处理文件：
   \begin{itemize}
-    \item \texttt{install-tl-windows.bat} 双击启动图形界面安装程序（简单安装）；
-    \item \texttt{install-tl-advanced.bat} 双击启动图形界面安装程序（定制安装）；
+    \item \texttt{install-tl-windows.bat} 双击启动图形界面安装程序，可以在图形安装界面的 Advance 选项中定制安装；
     \item 在命令提示符中输入 \texttt{install-tl-windows.bat -no-gui} 启动文本界面安装程序。
   \end{itemize}
   \item 用于 Linux 的 Perl 脚本 \texttt{install-tl} ：


### PR DESCRIPTION
新版的 TeXLive 只保留了 `install-tl-windows.bat`, 定制方式改在了 `gui` 界面的 Advance 选项中.