### PR TITLE
改进针对“Linux + XeTeX + 发行版中字体”的说明

### DIFF
--- a/src/chap/app.A.install.tex
+++ b/src/chap/app.A.install.tex
@@ -48,11 +48,13 @@
 \end{itemize}
 另外也可以下载在线安装程序 \texttt{install-tl.zip}，包含以上所有安装脚本。安装过程中会从 CTAN 软件源下载所有组件。
 
-Linux 下 \hologo{TeXLive} 安装完毕后，一般还需要在 root 权限下进行以下操作，使得 \hologo{XeLaTeX} 能正确通过 \pkg{fontspec}
-等宏包使用字体\footnote{\url{https://www.tug.org/texlive/doc/texlive-zh-cn/texlive-zh-cn.pdf}，
-可用 \texttt{texdoc texlive-zh-cn} 在本地打开。}：
+Linux 下 \hologo{TeXLive} 安装完毕后，一般还需要在 root 权限\footnote{
+  若无 root 权限，也有用户级配置方法。详见 \url{https://www.tug.org/texlive/doc/texlive-zh-cn/texlive-zh-cn.pdf}，可用 \texttt{texdoc texlive-zh-cn} 在本地打开。
+}下进行以下操作，否则 \hologo{XeTeX} 不支持按字体的英文名称调用 \TeX{} 发行版中的字体\footnote{
+  若不操作，亦可按字体的文件名调用；无论是否操作，调用系统字体都不受限制，\hologo{LuaTeX} 也不受限制。调用字体需使用 \pkg{fontspec} 宏包，详见~\ref{subsec:fontspec}~节。
+}：
 \begin{enumerate}
-  \item 将 \texttt{texlive-fontconfig.conf} 文件复制到 \texttt{/etc/fonts/conf.d/09-texlive.conf}。
+  \item 将 \texttt{texlive-fontconfig.conf} 文件\footnote{运行 \texttt{kpsewhich --expand-var '\$TEXMFVAR/fonts/conf/'} 可查看该文件所在目录。}复制到 \texttt{/etc/fonts/conf.d/09-texlive.conf}。
   \item 运行 \texttt{fc-cache -fsv}。
 \end{enumerate}
 

--- a/src/chap/chap.05.style.tex
+++ b/src/chap/chap.05.style.tex
@@ -198,8 +198,7 @@ He likes {\LARGE large and
 
 \index{xelatex@\texttt{xelatex} 命令}
 \index{lualatex@\texttt{lualatex} 命令}
-\texttt{xelatex} 和 \texttt{lualatex} 编译命令能够支持直接调用系统和 \TeX{} 发行版中的 \texttt{.ttf} 或 \texttt{.otf} 格式字体%
-\footnote{Linux 下的 \hologo{TeXLive} 为了令 \hologo{XeTeX} 使用 OpenType 字体，需要额外的配置。详见附录 \ref{app:install}。}。
+\texttt{xelatex} 和 \texttt{lualatex} 编译命令能够支持直接调用系统和 \TeX{} 发行版中的 \texttt{.ttf} 或 \texttt{.otf} 格式字体。
 相比于前文介绍的字体宏包，我们有了更多自由修改字体的余地。
 
 \pkgindex{fontspec}
@@ -212,7 +211,9 @@ He likes {\LARGE large and
 \cmd{setsansfont}\marg{font name}\oarg{font features} \\
 \cmd{setmonofont}\marg{font name}\oarg{font features}
 \end{command}
-其中 \Arg{font name} 使用字体的文件名（带扩展名）或者字体的英文名称。\Arg{font features} 用来
+其中 \Arg{font name} 使用字体的文件名（带扩展名）或者字体的英文名称\footnote{
+	在 Linux 下使用 \hologo{XeTeX} 调用 \TeX{} 发行版中的字体，若不额外配置，则只能按文件名调用；按附录 \ref{subsec:install-dists} 配置 \texttt{texlive-fontconfig.conf} 后，才支持按字体的英文名称调用。其它操作系统、引擎、系统字体无此限制。详情请参考 \pkg{fontspec} 文档。
+}。\Arg{font features} 用来
 手动配置对应的粗体或斜体，比如为 Windows 下的无衬线字体 Arial 配置粗体和斜体（通常情况下自动检测
 并设置对应的粗体和斜体，无需手动指定）：
 \begin{verbatim}


### PR DESCRIPTION
Resolves #112

请参考 https://github.com/CTeX-org/lshort-zh-cn/issues/112#issuecomment-4166747446 中的讨论与说明。

<details>
<summary>本地编译生成的 PDF 截图</summary>


<img width="1021" height="465" alt="图片" src="https://github.com/user-attachments/assets/ef9647a8-ec26-4e5c-ae3a-4c4d4b711737" />
<img width="1013" height="225" alt="图片" src="https://github.com/user-attachments/assets/0bc1a59b-c9d5-423d-9ed9-01d768312f7d" />
<img width="987" height="225" alt="图片" src="https://github.com/user-attachments/assets/734e599d-34b3-4cc7-bb49-98b4dd932c0a" />

---


<img width="1019" height="225" alt="图片" src="https://github.com/user-attachments/assets/4fd3e654-3cab-43b4-b106-b73833662e9b" />
<img width="968" height="187" alt="图片" src="https://github.com/user-attachments/assets/fa2825a1-d24b-4fdf-b7ab-80e839d8a316" />

</details>


---

另：有时间的话，建议列出编译必须的宏包。我[安装的宏包比较少](https://bithesis.bitnp.net/guide/getting-started.html#%E7%B2%BE%E7%AE%80%E5%AE%89%E8%A3%85%E5%86%85%E5%AE%B9)，需要`tlmgr install yhmath cm-unicode makecell`才能编译。
